### PR TITLE
Lowercase flag codes

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -52,7 +52,7 @@ class Factory
         [$name, $ratio] = $this->splitRatioAndName($name);
 
         return new Flag(
-            $this->contents($name, $ratio),
+            $this->contents(strtolower($name), $ratio),
             $this->attributes($class, $attributes)
         );
     }


### PR DESCRIPTION
Flags aren't visible when passing uppercase codes on operating systems that have case sensitive filesystems.
Since all SVG filenames are lowercase we can force lowercase on the code. 